### PR TITLE
added .github/CONTRIBUTING.md; taken from picosdk-c-sharp-examples

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+We welcome contributions to the *picosdk-c-sharp-examples* repository. By contributing to this repository, you agree to abide by our [code of conduct](CODE_OF_CONDUCT.md).
+
+## Steps to contribute
+
+1. Fork, then clone the repository:
+
+```
+git clone https://github.com/YOUR-USERNAME/picosdk-ethernet-protocol-examples
+```
+
+2. Create a new branch - specify a name in lowercase, using hyphens to link words e.g. `fft-example`
+
+3. Push to the new branch on your fork, and then submit a pull request.
+
+We will then review the pull request.
+
+## Pull request guidelines
+
+* Include the author name, date, and description of new file (or of change to existing file) as a note in the file header
+* If contributing a new file, ensure that it is in the correct sub-folder for the driver
+* [Commit messages](https://chris.beams.io/posts/git-commit/#seven-rules) should clearly communicate the reason for the change


### PR DESCRIPTION
Ronny Errmann, 2022-01-16
README.md links to .github/CONTRIBUTING.md, which was not present.
The file was taken from picosdk-c-sharp-examples/.github/CONTRIBUTING.md
and line 10 modified to the current repository